### PR TITLE
Routes ngs-stats requests through igo-qc server

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -601,6 +601,25 @@ def project_info(pId):
 
     return create_resp(True, 'success', data)
 
+@app.route('/getCellRangerSample', methods=['GET'])
+def get_cell_ranger_sample():
+    args = request.args
+    ngs_type = args.get("type")
+    project = args.get("project")
+
+    app.logger.info("ARGS " % ())
+    path = "/ngs-stats/getCellRangerSample?project=%s&type=%s" % (project, ngs_type)
+    ngs_stats_url = "%s/%s" % (NGS_STATS_API_ROOT, path)
+    app.logger.info('URL: %s' % ngs_stats_url)
+
+    resp = s.get(ngs_stats_url, verify=False)
+    content_bytes = resp.content
+    content = json.loads(content_bytes)
+    if 'data' in content.keys() and content['data']:
+        app.logger.info('Successful Response - Returning CellRanger Samples for project=%s type=%s' % (project, ngs_type))
+        return create_resp(True, 'success', content['data'])
+
+    return create_resp(False, "No CellRanger Sample (project=%s&type=%s)" % (project, ngs_type))
 
 @app.route('/ngsStatsDownload', methods=['GET'])
 def download_ngs_stats_file():
@@ -624,7 +643,7 @@ def download_ngs_stats_file():
     content = json.loads(content_bytes)
 
     if 'data' in content.keys() and content['data']:
-        return create_resp(True, 'success', { 'data': content['data'] })
+        return create_resp(True, 'success', content['data'])
 
     return create_resp(False, "No Download (run=%s&project=%s&sample=%s&type=%s&download=%s)" % (run, project, sample, ngs_type, download), None)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -601,13 +601,30 @@ def project_info(pId):
 
     return create_resp(True, 'success', data)
 
+@app.route('/getCrosscheckMetrics', methods=['GET'])
+def get_crosscheck_metrics():
+    args = request.args
+    projects = args.get("projects")
+
+    path = "/ngs-stats/getCrosscheckMetrics?projects=%s" % projects
+    ngs_stats_url = "%s/%s" % (NGS_STATS_API_ROOT, path)
+    app.logger.info('URL: %s' % ngs_stats_url)
+
+    resp = s.get(ngs_stats_url, verify=False)
+    content_bytes = resp.content
+    content = json.loads(content_bytes)
+    if 'data' in content.keys() and content['data']:
+        app.logger.info('Successful Response - Returning CrosscheckMetrics for projects=%s' % projects)
+        return create_resp(True, 'success', content['data'])
+
+    return create_resp(False, "No CrosscheckMetrics (projects=%s)" % projects, None)
+
 @app.route('/getCellRangerSample', methods=['GET'])
 def get_cell_ranger_sample():
     args = request.args
     ngs_type = args.get("type")
     project = args.get("project")
 
-    app.logger.info("ARGS " % ())
     path = "/ngs-stats/getCellRangerSample?project=%s&type=%s" % (project, ngs_type)
     ngs_stats_url = "%s/%s" % (NGS_STATS_API_ROOT, path)
     app.logger.info('URL: %s' % ngs_stats_url)
@@ -619,7 +636,7 @@ def get_cell_ranger_sample():
         app.logger.info('Successful Response - Returning CellRanger Samples for project=%s type=%s' % (project, ngs_type))
         return create_resp(True, 'success', content['data'])
 
-    return create_resp(False, "No CellRanger Sample (project=%s&type=%s)" % (project, ngs_type))
+    return create_resp(False, "No CellRanger Sample (project=%s&type=%s)" % (project, ngs_type), None)
 
 @app.route('/ngsStatsDownload', methods=['GET'])
 def download_ngs_stats_file():

--- a/static/seq-qc/src/components/project-page/components/qc-table.js
+++ b/static/seq-qc/src/components/project-page/components/qc-table.js
@@ -353,7 +353,7 @@ class QcTable extends React.Component {
                                 <div className={"xlsx-type-selector black-border-right hover"} onClick={() => downloadExcel(this.props.data, this.props.project || 'Project')}>
                                     <p className={"font-bold"}>Table Excel</p>
                                 </div>
-                                <a href={`${config.NGS_STATS}/ngs-stats/get-picard-project-excel/${this.props.project}`}>
+                                <a href={`${config.NGS_STATS}/ngs-stats/get-picard-project-excel/${this.props.project}`} target="_blank">
                                     <div className={"xlsx-type-selector hover"}>
                                         <p className={"font-bold"}>Picard Excel</p>
                                     </div>

--- a/static/seq-qc/src/components/project-page/project-page.spec.js
+++ b/static/seq-qc/src/components/project-page/project-page.spec.js
@@ -26,7 +26,7 @@ describe('ProjectPage', () => {
 
         mock = new MockAdapter(axios);
         mock.onGet(new RegExp(`${config.IGO_QC}/projectInfo/.*`)).reply(200, projectInfo);
-        mock.onGet(new RegExp(`${config.NGS_STATS}/ngs-stats/getCellRangerSample.*`)).reply(200, ngsStatsGraph);
+        mock.onGet(new RegExp(`${config.IGO_QC}/getCellRangerSample.*`)).reply(200, ngsStatsGraph);
 
         store = mockStore({
             projects: {

--- a/static/seq-qc/src/components/routers/run_router.js
+++ b/static/seq-qc/src/components/routers/run_router.js
@@ -145,7 +145,7 @@ const RunRouter = (props) => {
                 </td>
                 <td className={"text-align-center light-blue-border"}>
                     { runsWithPicard && runsWithPicard.has(name) ?
-                        <a href={`${config.NGS_STATS}/ngs-stats/get-picard-run-excel/${name}`}>
+                        <a href={`${config.NGS_STATS}/ngs-stats/get-picard-run-excel/${name}`} target="_blank">
                             <button className="btn btn-primary run-info-button picard-stats-btn">
                                 <FontAwesomeIcon className="em5 mskcc-light-blue" icon={faDna}/>
                             </button>

--- a/static/seq-qc/src/services/ngs-stats-service.js
+++ b/static/seq-qc/src/services/ngs-stats-service.js
@@ -21,7 +21,7 @@ import {downloadHtml} from "../utils/other-utils";
  */
 export const getCrosscheckMetrics = (projects) => {
     const projectList = projects.join(',');
-    return axios.get(`${config.NGS_STATS}/ngs-stats/getCrosscheckMetrics?projects=${projectList}`)
+    return axios.get(`${config.IGO_QC}/getCrosscheckMetrics?projects=${projectList}`)
         .then(getData)
         .catch(handleError)
 };

--- a/static/seq-qc/src/services/ngs-stats-service.js
+++ b/static/seq-qc/src/services/ngs-stats-service.js
@@ -66,13 +66,14 @@ export const getNgsStatsData = (recipe, projectId) => {
  * @param run
  * @returns {Promise<String>}
  */
-export const downloadNgsStatsFile = (type, sample, igoId, project, run) => {
+export const downloadNgsStatsFile = (type, sample, igoId, project, run, download=true) => {
     // e.g. [ "SC16-UN", "IGO_09335_O_1" ] => "SC16-UN_IGO_09335_O_1"
     sample = `${sample}_IGO_${igoId}`
-    return axios.get(`${config.NGS_STATS}/ngs-stats/getCellRangerFile?run=${run}&project=${project}&sample=${sample}&type=${type}`)
+    return axios.get(config.IGO_QC + `/ngsStatsDownload?type=${type}&sample=${sample}&project=${project}&run=${run}&download=${download}`)
         .then(res => {
             const payload = res['data'] || {};
-            const data = payload['data'];
+            const content = payload['data'];
+            const data = content['data'];
             downloadHtml(data, sample)
             return data;
         })

--- a/static/seq-qc/src/services/ngs-stats-service.js
+++ b/static/seq-qc/src/services/ngs-stats-service.js
@@ -72,8 +72,7 @@ export const downloadNgsStatsFile = (type, sample, igoId, project, run, download
     return axios.get(config.IGO_QC + `/ngsStatsDownload?type=${type}&sample=${sample}&project=${project}&run=${run}&download=${download}`)
         .then(res => {
             const payload = res['data'] || {};
-            const content = payload['data'];
-            const data = content['data'];
+            const data = payload['data'];
             downloadHtml(data, sample)
             return data;
         })
@@ -104,7 +103,7 @@ export const mapCellRangerRecipe = (recipe) => {
  * @returns {Promise<AxiosResponse<T>>}
  */
 const getCellRangerData = (projectId, type) => {
-    return axios.get(`${config.NGS_STATS}/ngs-stats/getCellRangerSample?project=${projectId}&type=${type}`)
+    return axios.get(`${config.IGO_QC}/getCellRangerSample?project=${projectId}&type=${type}`)
         .then(processCellRangerResponse)
         .catch(handleError)
 };


### PR DESCRIPTION
Routing ngs-stats endpoings through igo-qc to avoid certificate invalid issue w/ browser
* `/ngs-stats/getCrosscheckMetrics`
* `/ngs-stats/getCellRangerSample`
* `/ngs-stats/getCellRangerFile`